### PR TITLE
Unfinished tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@ utils
 =====
 
 Various useful stuff for Vimwiki
+
+
+## Run tests
+
+PYTHONPATH=.:$PYTHONPATH python -m pytest tests/

--- a/tests/test_vwunfinished.py
+++ b/tests/test_vwunfinished.py
@@ -1,0 +1,52 @@
+import unittest
+
+# Enable importing modules from parent directory
+import os
+parentdir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+os.sys.path.insert(0, parentdir)
+
+from vwunfinished import UnfinishedTasksCounter
+
+
+class TestVWUnfinished(unittest.TestCase):
+
+    def test_count_unfinished_tasks(self):
+        counter = UnfinishedTasksCounter(text=simple_text)
+        assert counter.count_unfinished_tasks() == 2
+
+    def test_count_unfinished_dashes(self):
+        counter = UnfinishedTasksCounter(text=multiple_list_types_text, bullets=["-"])
+        assert counter.count_unfinished_tasks() == 2
+
+        counter = UnfinishedTasksCounter(text=multiple_list_types_text)
+        assert counter.count_unfinished_tasks() == 3
+
+    def test_parse_section(self):
+        counter = UnfinishedTasksCounter(text=simple_text, section="## Todo")
+        assert counter.text == "## Todo\n\n* [ ] Finish vimwiki article"  # Or ending with \n?
+
+
+simple_text = """# 2019-05-18
+
+## Daily checklist
+
+* [ ] Take a vitamin C
+* [X] Eat your daily carrot!
+
+## Todo
+
+* [ ] Finish vimwiki article
+"""
+
+
+multiple_list_types_text = """# Text with more list types
+
+## List with dashes
+
+- [ ] First dashed thing
+- [ ] Second dashed thing
+
+## List with asterisks
+
+* [ ] And here we use asterisk
+"""

--- a/tests/test_vwunfinished.py
+++ b/tests/test_vwunfinished.py
@@ -36,6 +36,16 @@ class TestUnfinishedTasksCounter(unittest.TestCase):
         counter = UnfinishedTasksCounter(text=text_with_sublists, ignore_sublists=True)
         assert counter.count_unfinished_tasks() == 3
 
+    def test_toplevel_indented(self):
+        counter = UnfinishedTasksCounter(text=text_with_everything_indented)
+        assert counter.count_unfinished_tasks() == 5
+
+        counter = UnfinishedTasksCounter(text=text_with_everything_indented, ignore_sublists=True)
+        assert counter.count_unfinished_tasks() == 0
+
+        counter = UnfinishedTasksCounter(text=text_with_everything_indented, ignore_sublists=True, indentation_level=2)
+        assert counter.count_unfinished_tasks() == 2
+
 
 simple_text = """# 2019-05-18
 
@@ -83,6 +93,18 @@ simple_text_vimwiki_syntax = """= 2019-05-18 =
 == Todo ==
 
 * [ ] Finish vimwiki article
+"""
+
+
+text_with_everything_indented = """= TODO =
+
+  - [ ] Some long text so this needs
+    to be multi-line
+
+  - [ ] Top-level task, that is indented
+    - [ ] First nesting level
+      - [ ] Second nesting level
+      - [ ] Some micro action
 """
 
 
@@ -171,3 +193,8 @@ class TestArgparser(unittest.TestCase):
         cmd = "--path foo.md --ignore-sublists"
         args = parser.parse_args(cmd.split())
         assert args.ignore_sublists
+
+    def test_indentation_level(self):
+        cmd = "--path foo.md --indentation-level=2"
+        args = parser.parse_args(cmd.split())
+        assert args.indentation_level == 2

--- a/tests/test_vwunfinished.py
+++ b/tests/test_vwunfinished.py
@@ -1,13 +1,14 @@
+import six.moves
 import datetime
 import unittest
-from mock import patch, Mock
+from mock import patch, Mock, mock_open
 
 # Enable importing modules from parent directory
 import os
 parentdir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 os.sys.path.insert(0, parentdir)
 
-from vwunfinished import UnfinishedTasksCounter, parser
+from vwunfinished import UnfinishedTasksCounter, VimwikiFileProvider, parser
 
 
 class TestVWUnfinished(unittest.TestCase):
@@ -85,6 +86,35 @@ simple_text_vimwiki_syntax = """= 2019-05-18 =
 
 * [ ] Finish vimwiki article
 """
+
+
+class TestVimwikiFileProvider(unittest.TestCase):
+
+    @patch("os.path.expanduser", side_effect=lambda x: x.replace("~", "/home/mockee"))
+    def test_path(self, *args):
+        provider = VimwikiFileProvider(path="~/foo.md")
+        assert provider.path == "/home/mockee/foo.md"
+
+        provider = VimwikiFileProvider(date="2019-05-19", filetype="md")
+        assert provider.path == "/home/mockee/vimwiki/diary/2019-05-19.md"
+
+        provider = VimwikiFileProvider(date="2019-05-19", wiki_path="/foo/", diary_dir="bar", filetype="wiki")
+        assert provider.path == "/foo/bar/2019-05-19.wiki"
+
+    def test_path_precedence(self):
+        provider = VimwikiFileProvider(path="foo.md", date="2019-05-19")
+        assert provider.path == "foo.md"
+
+    def test_unspecified_path_exception(self):
+        with self.assertRaises(ValueError) as context:
+            provider = VimwikiFileProvider()
+            provider.path
+        assert "not enough information " in str(context.exception)
+
+    @patch("{}.open".format(six.moves.builtins.__name__), mock_open(read_data=simple_text))
+    def test_content(self):
+        provider = VimwikiFileProvider(path="whatever-we-mock-it.md")
+        assert "## Daily checklist" in provider.content
 
 
 class TestArgparser(unittest.TestCase):

--- a/tests/test_vwunfinished.py
+++ b/tests/test_vwunfinished.py
@@ -8,10 +8,13 @@ import os
 parentdir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 os.sys.path.insert(0, parentdir)
 
-from vwunfinished import UnfinishedTasksCounter, VimwikiFileProvider, parser
+from vwunfinished import (UnfinishedTasksCounter,
+                          VimwikiFileProvider,
+                          vimwiki_unfinished_tasks,
+                          parser,)
 
 
-class TestVWUnfinished(unittest.TestCase):
+class TestUnfinishedTasksCounter(unittest.TestCase):
 
     def test_count_unfinished_tasks(self):
         counter = UnfinishedTasksCounter(text=simple_text)
@@ -117,7 +120,16 @@ class TestVimwikiFileProvider(unittest.TestCase):
         assert "## Daily checklist" in provider.content
 
 
+class TestUnfinishedTasksFunction(unittest.TestCase):
+
+    @patch("{}.open".format(six.moves.builtins.__name__), mock_open(read_data=simple_text))
+    def test_vimwiki_unfinished_tasks(self):
+        assert vimwiki_unfinished_tasks(path="whatever-we-mock-it.md") == 2
+        assert vimwiki_unfinished_tasks(path="whatever-we-mock-it.md", section="## Daily checklist") == 1
+
+
 class TestArgparser(unittest.TestCase):
+
     def test_input(self):
         cmd = "--path /foo/bar/baz.md"
         args = parser.parse_args(cmd.split())

--- a/tests/test_vwunfinished.py
+++ b/tests/test_vwunfinished.py
@@ -25,6 +25,13 @@ class TestVWUnfinished(unittest.TestCase):
         counter = UnfinishedTasksCounter(text=simple_text, section="## Todo")
         assert counter.text == "## Todo\n\n* [ ] Finish vimwiki article"  # Or ending with \n?
 
+    def test_sublists_counter(self):
+        counter = UnfinishedTasksCounter(text=text_with_sublists, count_sublists=True)
+        assert counter.count_unfinished_tasks() == 5
+
+        counter = UnfinishedTasksCounter(text=text_with_sublists, count_sublists=False)
+        assert counter.count_unfinished_tasks() == 3
+
 
 simple_text = """# 2019-05-18
 
@@ -49,4 +56,14 @@ multiple_list_types_text = """# Text with more list types
 ## List with asterisks
 
 * [ ] And here we use asterisk
+"""
+
+
+text_with_sublists = """# Text with sublists
+
+- [ ] Some simple task
+- [ ] Major task composed of multiple actions
+    - [ ] Some nested task
+    - [ ] Another minor task
+- [ ] Another simple task
 """

--- a/tests/test_vwunfinished.py
+++ b/tests/test_vwunfinished.py
@@ -3,11 +3,6 @@ import datetime
 import unittest
 from mock import patch, Mock, mock_open
 
-# Enable importing modules from parent directory
-import os
-parentdir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-os.sys.path.insert(0, parentdir)
-
 from vwunfinished import (UnfinishedTasksCounter,
                           VimwikiFileProvider,
                           vimwiki_unfinished_tasks,

--- a/tests/test_vwunfinished.py
+++ b/tests/test_vwunfinished.py
@@ -30,10 +30,10 @@ class TestUnfinishedTasksCounter(unittest.TestCase):
         assert counter.text == "== Todo ==\n\n* [ ] Finish vimwiki article"  # Or ending with \n?
 
     def test_sublists_counter(self):
-        counter = UnfinishedTasksCounter(text=text_with_sublists, count_sublists=True)
+        counter = UnfinishedTasksCounter(text=text_with_sublists, ignore_sublists=False)
         assert counter.count_unfinished_tasks() == 5
 
-        counter = UnfinishedTasksCounter(text=text_with_sublists, count_sublists=False)
+        counter = UnfinishedTasksCounter(text=text_with_sublists, ignore_sublists=True)
         assert counter.count_unfinished_tasks() == 3
 
 
@@ -163,11 +163,11 @@ class TestArgparser(unittest.TestCase):
         args = parser.parse_args(cmd.split())
         assert args.bullets == ["*"]
 
-    def test_count_sublists(self):
+    def test_ignore_sublists(self):
         cmd = "--path foo.md"
         args = parser.parse_args(cmd.split())
-        assert not args.count_sublists
+        assert not args.ignore_sublists
 
-        cmd = "--path foo.md --count-sublists"
+        cmd = "--path foo.md --ignore-sublists"
         args = parser.parse_args(cmd.split())
-        assert args.count_sublists
+        assert args.ignore_sublists

--- a/tests/test_vwunfinished.py
+++ b/tests/test_vwunfinished.py
@@ -25,6 +25,9 @@ class TestVWUnfinished(unittest.TestCase):
         counter = UnfinishedTasksCounter(text=simple_text, section="## Todo")
         assert counter.text == "## Todo\n\n* [ ] Finish vimwiki article"  # Or ending with \n?
 
+        counter = UnfinishedTasksCounter(text=simple_text_vimwiki_syntax, section="== Todo ==")
+        assert counter.text == "== Todo ==\n\n* [ ] Finish vimwiki article"  # Or ending with \n?
+
     def test_sublists_counter(self):
         counter = UnfinishedTasksCounter(text=text_with_sublists, count_sublists=True)
         assert counter.count_unfinished_tasks() == 5
@@ -66,4 +69,17 @@ text_with_sublists = """# Text with sublists
     - [ ] Some nested task
     - [ ] Another minor task
 - [ ] Another simple task
+"""
+
+
+simple_text_vimwiki_syntax = """= 2019-05-18 =
+
+== Daily checklist ==
+
+* [ ] Take a vitamin C
+* [X] Eat your daily carrot!
+
+== Todo ==
+
+* [ ] Finish vimwiki article
 """

--- a/tests/test_vwunfinished.py
+++ b/tests/test_vwunfinished.py
@@ -107,7 +107,7 @@ class TestVimwikiFileProvider(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             provider = VimwikiFileProvider()
             provider.path
-        assert "not enough information " in str(context.exception)
+        assert "not have enough information " in str(context.exception)
 
     @patch("{}.open".format(six.moves.builtins.__name__), mock_open(read_data=simple_text))
     def test_content(self):

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -26,7 +26,7 @@ def vimwiki_unfinished_tasks(path=None, date=None, section=None, bullets=None, c
                              wiki_path=None, diary_dir=None, filetype=None):
     """
     Return a count of unfinished tasks in specified vimwiki file
-    Consider this function to be an API. It's attributes and return type will remain backwards compatible.
+    Consider this function to be an API. Its attributes and return type will remain backwards compatible.
 
     :param str path: Path to a vimwiki file
     :param str date: Use diary file for given date (in YYYY-MM-DD format)

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -110,10 +110,16 @@ class VimwikiFileProvider(object):
 
 def main():
     args = parser.parse_args()
-    if not os.path.exists(args.path):
+    try:
+        print(vimwiki_unfinished_tasks(**args.__dict__))
+
+    except IOError as ex:
+        print(ex)
         sys.exit(11)
 
-    print(vimwiki_unfinished_tasks(**args.__dict__))
+    except ValueError as ex:
+        print(ex)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -1,0 +1,39 @@
+class UnfinishedTasksCounter(object):
+    def __init__(self, path=None, text=None, section=None, bullets=None):
+        self.path = path
+        self.bullets = bullets or ["-", "*"]
+        self.section = section
+        self._text = text
+
+    @property
+    def text(self):
+        if not self.section:
+            return self._text
+        level = self.section.split()[0]
+        start = self._text.find(self.section)
+        end = self._text.find(level, start + len(self.section))
+        return self._text[start:end]
+
+    @property
+    def unfinished_bullet_str(self):
+        return tuple(["{} [ ]".format(x) for x in self.bullets])
+
+    def count_unfinished_tasks(self):
+        count = 0
+        for line in self.text.split("\n"):
+            if line.startswith(self.unfinished_bullet_str):
+                count += 1
+        return count
+
+
+def vimwiki_unfinished_tasks():
+    # API
+    pass
+
+
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -1,3 +1,23 @@
+import os
+import argparse
+from datetime import datetime
+
+parser = argparse.ArgumentParser(description="Count unfinished vimwiki tasks")
+parser.add_argument("--count-sublists", action="store_true", help="Do you wish to count sublists?")
+parser.add_argument("--section", help="Count tasks only in specified section (e.g. '== Todo =='")
+parser.add_argument("--bullets", help="Bullet symbols (e.g. '*-')", type=list)
+
+parser.add_argument("--diary-dir", default="diary", help="Use nonstandard diary directory")
+parser.add_argument("--wiki-path", default="~/vimwiki", help="Use nonstandard wiki path",
+                    type=lambda x: os.path.expanduser(x))
+
+input_parser = parser.add_mutually_exclusive_group(required=True)
+input_parser.add_argument("--path", help="Path to a vimwiki file")
+input_parser.add_argument("--date", help="Use diary file for given date (in YYYY-MM-DD format)")
+input_parser.add_argument("--today", help="Use diary file for today", dest="date",
+                          action="store_const", const=str(datetime.now().date()))
+
+
 class UnfinishedTasksCounter(object):
     def __init__(self, path=None, text=None, section=None, bullets=None, count_sublists=True):
         self.path = path
@@ -39,7 +59,10 @@ def vimwiki_unfinished_tasks():
 
 
 def main():
-    pass
+    args = parser.parse_args()
+    counter = UnfinishedTasksCounter(path=args.path, section=args.section, bullets=args.bullets,
+                                     count_sublists=args.count_sublists)
+    print(counter.count_unfinished_tasks())
 
 
 if __name__ == "__main__":

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import os
 import sys
 import argparse

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -11,6 +11,7 @@ parser.add_argument("--bullets", help="Bullet symbols (e.g. '*-')", type=list)
 parser.add_argument("--diary-dir", default="diary", help="Use nonstandard diary directory")
 parser.add_argument("--wiki-path", default="~/vimwiki", help="Use nonstandard wiki path",
                     type=lambda x: os.path.expanduser(x))
+parser.add_argument("--filetype", default="wiki", choices=["wiki", "md"], help="What filetype do you use?")
 
 input_parser = parser.add_mutually_exclusive_group(required=True)
 input_parser.add_argument("--path", help="Path to a vimwiki file")
@@ -20,8 +21,7 @@ input_parser.add_argument("--today", help="Use diary file for today", dest="date
 
 
 class UnfinishedTasksCounter(object):
-    def __init__(self, path=None, text=None, section=None, bullets=None, count_sublists=True):
-        self.path = path
+    def __init__(self, text=None, section=None, bullets=None, count_sublists=True):
         self.bullets = bullets or ["-", "*"]
         self.section = section
         self._text = text
@@ -54,6 +54,31 @@ class UnfinishedTasksCounter(object):
         return len(self.unfinished_tasks)
 
 
+class VimwikiFileProvider(object):
+    def __init__(self, path=None, date=None, wiki_path="~/vimwiki", diary_dir="diary", filetype="wiki"):
+        self._path = path
+        self.date = date
+        self.wiki_path = wiki_path
+        self.diary_dir = diary_dir
+        self.filetype = filetype
+
+    @property
+    def path(self):
+        if self._path:
+            return os.path.expanduser(self._path)
+
+        if self.date:
+            return os.path.join(*[os.path.expanduser(self.wiki_path), self.diary_dir,
+                                  ".".join([self.date, self.filetype])])
+
+        raise ValueError("I have not enough information to determine a file")
+
+    @property
+    def content(self):
+        with open(self.path, "r") as f:
+            return f.read()
+
+
 def vimwiki_unfinished_tasks():
     # API
     pass
@@ -63,7 +88,10 @@ def main():
     args = parser.parse_args()
     if not os.path.exists(args.path):
         sys.exit(11)
-    counter = UnfinishedTasksCounter(path=args.path, section=args.section, bullets=args.bullets,
+
+    provider = VimwikiFileProvider(path=args.path, date=args.date, wiki_path=args.wiki_path,
+                                   diary_dir=args.diary_dir, filetype=args.filetype)
+    counter = UnfinishedTasksCounter(text=provider.content, section=args.section, bullets=args.bullets,
                                      count_sublists=args.count_sublists)
     print(counter.count_unfinished_tasks())
 

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import argparse
 from datetime import datetime
 
@@ -60,6 +61,8 @@ def vimwiki_unfinished_tasks():
 
 def main():
     args = parser.parse_args()
+    if not os.path.exists(args.path):
+        sys.exit(11)
     counter = UnfinishedTasksCounter(path=args.path, section=args.section, bullets=args.bullets,
                                      count_sublists=args.count_sublists)
     print(counter.count_unfinished_tasks())

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -6,7 +6,7 @@ import argparse
 from datetime import datetime
 
 parser = argparse.ArgumentParser(description="Count unfinished vimwiki tasks")
-parser.add_argument("--count-sublists", action="store_true", help="Do you wish to count sublists?")
+parser.add_argument("--ignore-sublists", action="store_true", help="Do you wish to ignore sublists?")
 parser.add_argument("--section", help="Count tasks only in specified section (e.g. '== Todo =='")
 parser.add_argument("--bullets", help="Bullet symbols (e.g. '*-')", type=list)
 
@@ -22,7 +22,7 @@ input_parser.add_argument("--today", help="Use diary file for today", dest="date
                           action="store_const", const=str(datetime.now().date()))
 
 
-def vimwiki_unfinished_tasks(path=None, date=None, section=None, bullets=None, count_sublists=None,
+def vimwiki_unfinished_tasks(path=None, date=None, section=None, bullets=None, ignore_sublists=None,
                              wiki_path=None, diary_dir=None, filetype=None):
     """
     Return a count of unfinished tasks in specified vimwiki file
@@ -32,7 +32,7 @@ def vimwiki_unfinished_tasks(path=None, date=None, section=None, bullets=None, c
     :param str date: Use diary file for given date (in YYYY-MM-DD format)
     :param str section: Count tasks only in specified section (e.g. '== Daily checklist ==')
     :param list bullets: Bullet symbols, e.g. ["*", "-"]
-    :param bool count_sublists: Do you wish to count sublists?
+    :param bool ignore_sublists: Do you wish to ignore sublists?
     :param str wiki_path: Use nonstandard wiki path (can contain ~ for home directory)
     :param str diary_dir: Use nonstandard diary directory
     :param str filetype: Either "wiki" or "md"
@@ -45,16 +45,16 @@ def vimwiki_unfinished_tasks(path=None, date=None, section=None, bullets=None, c
     provider = VimwikiFileProvider(path=path, date=date, wiki_path=wiki_path,
                                    diary_dir=diary_dir, filetype=filetype)
     counter = UnfinishedTasksCounter(text=provider.content, section=section, bullets=bullets,
-                                     count_sublists=count_sublists)
+                                     ignore_sublists=ignore_sublists)
     return counter.count_unfinished_tasks()
 
 
 class UnfinishedTasksCounter(object):
-    def __init__(self, text=None, section=None, bullets=None, count_sublists=True):
+    def __init__(self, text=None, section=None, bullets=None, ignore_sublists=False):
         self.bullets = bullets or ["-", "*"]
         self.section = section
         self._text = text
-        self.count_sublists = count_sublists
+        self.ignore_sublists = ignore_sublists
 
     @property
     def text(self):
@@ -73,7 +73,7 @@ class UnfinishedTasksCounter(object):
     def unfinished_tasks(self):
         tasks = []
         for line in self.text.split("\n"):
-            if self.count_sublists:
+            if not self.ignore_sublists:
                 line = line.strip()
             if line.startswith(self.unfinished_bullet_str):
                 tasks.append(line)

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -100,7 +100,7 @@ class VimwikiFileProvider(object):
             return os.path.join(*[os.path.expanduser(self.wiki_path), self.diary_dir,
                                   ".".join([self.date, self.filetype])])
 
-        raise ValueError("I have not enough information to determine a file")
+        raise ValueError("I do not have enough information to determine a file")
 
     @property
     def content(self):

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -22,6 +22,33 @@ input_parser.add_argument("--today", help="Use diary file for today", dest="date
                           action="store_const", const=str(datetime.now().date()))
 
 
+def vimwiki_unfinished_tasks(path=None, date=None, section=None, bullets=None, count_sublists=None,
+                             wiki_path=None, diary_dir=None, filetype=None):
+    """
+    Return a count of unfinished tasks in specified vimwiki file
+    Consider this function to be an API. It's attributes and return type will remain backwards compatible.
+
+    :param str path: Path to a vimwiki file
+    :param str date: Use diary file for given date (in YYYY-MM-DD format)
+    :param str section: Count tasks only in specified section (e.g. '== Daily checklist ==')
+    :param list bullets: Bullet symbols, e.g. ["*", "-"]
+    :param bool count_sublists: Do you wish to count sublists?
+    :param str wiki_path: Use nonstandard wiki path (can contain ~ for home directory)
+    :param str diary_dir: Use nonstandard diary directory
+    :param str filetype: Either "wiki" or "md"
+
+    :raise: ValueError if there is not enough information to determine a wiki file
+    :raise: IOError if wiki file doesn't exist
+
+    :return: int
+    """
+    provider = VimwikiFileProvider(path=path, date=date, wiki_path=wiki_path,
+                                   diary_dir=diary_dir, filetype=filetype)
+    counter = UnfinishedTasksCounter(text=provider.content, section=section, bullets=bullets,
+                                     count_sublists=count_sublists)
+    return counter.count_unfinished_tasks()
+
+
 class UnfinishedTasksCounter(object):
     def __init__(self, text=None, section=None, bullets=None, count_sublists=True):
         self.bullets = bullets or ["-", "*"]
@@ -81,21 +108,12 @@ class VimwikiFileProvider(object):
             return f.read()
 
 
-def vimwiki_unfinished_tasks():
-    # API
-    pass
-
-
 def main():
     args = parser.parse_args()
     if not os.path.exists(args.path):
         sys.exit(11)
 
-    provider = VimwikiFileProvider(path=args.path, date=args.date, wiki_path=args.wiki_path,
-                                   diary_dir=args.diary_dir, filetype=args.filetype)
-    counter = UnfinishedTasksCounter(text=provider.content, section=args.section, bullets=args.bullets,
-                                     count_sublists=args.count_sublists)
-    print(counter.count_unfinished_tasks())
+    print(vimwiki_unfinished_tasks(**args.__dict__))
 
 
 if __name__ == "__main__":

--- a/vwunfinished.py
+++ b/vwunfinished.py
@@ -1,9 +1,10 @@
 class UnfinishedTasksCounter(object):
-    def __init__(self, path=None, text=None, section=None, bullets=None):
+    def __init__(self, path=None, text=None, section=None, bullets=None, count_sublists=True):
         self.path = path
         self.bullets = bullets or ["-", "*"]
         self.section = section
         self._text = text
+        self.count_sublists = count_sublists
 
     @property
     def text(self):
@@ -18,12 +19,18 @@ class UnfinishedTasksCounter(object):
     def unfinished_bullet_str(self):
         return tuple(["{} [ ]".format(x) for x in self.bullets])
 
-    def count_unfinished_tasks(self):
-        count = 0
+    @property
+    def unfinished_tasks(self):
+        tasks = []
         for line in self.text.split("\n"):
+            if self.count_sublists:
+                line = line.strip()
             if line.startswith(self.unfinished_bullet_str):
-                count += 1
-        return count
+                tasks.append(line)
+        return tasks
+
+    def count_unfinished_tasks(self):
+        return len(self.unfinished_tasks)
 
 
 def vimwiki_unfinished_tasks():


### PR DESCRIPTION
This PR adds a script that prints how many unfinished tasks are remaining in wiki file.

Example usage:

    [jkadlcik@chromie utils]$ ./vwunfinished.py --today --filetype md --count-sublists
    9

It also provides a convenient `vimwiki_unfinished_tasks` function that can be imported and used from some other python code.

The reason for this is ... status bars! I want to show how many remaining tasks for today I have, in my status bar.