### PR TITLE
Use python3 so we can ship it to fedora

### DIFF
--- a/vmtree.sh
+++ b/vmtree.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Create a linkified vimwiki tree of the specified directory and subdirectories.
 # It takes one argument: the base directory of the vimwiki.
 # For the links to make sense, save the output of this script into a file located in this base directory.

--- a/vwtags.py
+++ b/vwtags.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function


### PR DESCRIPTION
Fedora is now python3 only, so we need to update the shebang, so I can package it.