### PR TITLE
Switched to '/usr/bin/env' instead of '/bin/bash'

### DIFF
--- a/vmtree.sh
+++ b/vmtree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create a linkified vimwiki tree of the specified directory and subdirectories.
 # It takes one argument: the base directory of the vimwiki.
 # For the links to make sense, save the output of this script into a file located in this base directory.


### PR DESCRIPTION
Some systems don't have bash at `/bin/bash`, such as FreeBSD. So it is better practice to do `/usr/bin/env bash`, to support more Unix *(and Unix like)* systems by default.   